### PR TITLE
Make it work on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,28 @@ Wiktionary data come from kaikki.org and [Dbnary](https://kaiko.getalp.org/about
 - pigz or gzip
 
 ## Create files
-
+**Unix**:
 ```
 $ python -m venv .venv
 $ source .venv/bin/activate.fish
 $ python -m pip install .
 $ proficiency en
+```
+
+**Windows**:
+
+First install wget with
+```
+winget install -e --id JernejSimoncic.Wget
+```
+and re-open the console window.
+
+Then activate Python and run the program:
+```
+python -m venv .venv
+.\.venv\Scripts\activate
+python -m pip install .
+proficiency en
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,26 +5,23 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "Proficiency"
 version = "0.5.12"
-authors = [
-    {name = "xxyzz"}
-]
+authors = [{ name = "xxyzz" }]
 description = "Create language files for WordDumb."
 readme = "README.md"
 requires-python = ">=3.11"
-license = {text = "GNU General Public License v3 or later (GPLv3+)"}
+license = { text = "GNU General Public License v3 or later (GPLv3+)" }
 dependencies = [
     "lemminflect",
     "OpenCC",
     "wordfreq[mecab]",
     "wiktextract-lemmatization @ git+https://github.com/Vuizur/wiktextract-lemmatization@37f438eb973364de4d5e70959ee1c2aa26bf5ba5",
     "pyoxigraph",
+    # mecab with prerelease version for 3.12 wheels
+    "mecab-python3>=1.0.9.dev4 ; platform_system == 'Windows'",
 ]
 
 [project.optional-dependencies]
-dev = [
-    "mypy",
-    "ruff",
-]
+dev = ["mypy", "ruff"]
 
 [project.scripts]
 proficiency = "proficiency.main:main"
@@ -51,12 +48,12 @@ ignore_missing_imports = true
 [tool.typos]
 type.csv.check-file = false
 type.json.check-file = false
-default.extend-words = {"Formes" = "Formes"}
+default.extend-words = { "Formes" = "Formes" }
 
 [tool.ruff.lint]
 select = [
-    "E",  # pycodestyle error
-    "F",  # Pyflakes
-    "I",  # isort
-    "W",  # pycodestyle warning
+    "E", # pycodestyle error
+    "F", # Pyflakes
+    "I", # isort
+    "W", # pycodestyle warning
 ]

--- a/src/proficiency/main.py
+++ b/src/proficiency/main.py
@@ -27,12 +27,27 @@ WIKITEXTRACT_LANGUAGES = frozenset(["en", "zh", "fr"])
 def compress(file_path: Path) -> None:
     compressed_path = file_path.with_suffix(file_path.suffix + ".bz2")
     compressed_path.unlink(missing_ok=True)
-    subprocess.run(
-        ["lbzip2" if which("lbzip2") is not None else "bzip2", "-k", str(file_path)],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+
+    if which("lbzip2") is None and which("bzip2") is None:
+        import bz2
+
+        # Use pure python implementation of bzip2 compression
+        with open(file_path, "rb") as input_file:
+            data = input_file.read()
+            compressed_data = bz2.compress(data)
+            with open(compressed_path, "wb") as output_file:
+                output_file.write(compressed_data)
+    else:
+        subprocess.run(
+            [
+                "lbzip2" if which("lbzip2") is not None else "bzip2",
+                "-k",
+                str(file_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
 
 def create_wiktionary_files_from_kaikki(


### PR DESCRIPTION
A first test run with 'fr' seems to have worked well. I added a dependency to the prerelease version of python-mecab, because the current release does not have 3.12 wheels and building them requires the original C library, so is not really trivial. Other than that I added some workarounds for several command line tools.